### PR TITLE
feat: add speech synthesis for new flashcards

### DIFF
--- a/frontend/src/components/card-form.jsx
+++ b/frontend/src/components/card-form.jsx
@@ -5,6 +5,7 @@ import { Button } from "./ui/button"
 import { Textarea } from "./ui/textarea"
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card"
 import { toast } from "react-toastify";
+import { Volume2 } from "lucide-react"
 import { useCards } from "../context/CardContext"
 import { assets } from '../assets/assets'
 
@@ -15,6 +16,19 @@ export function CardForm({ editingCard, onCancel }) {
   const [frontImage, setFrontImage] = useState(null)
   const [backImage, setBackImage] = useState(null)
 
+  const speakText = (text) => {
+    if (!text?.trim()) {
+      toast.error("Please enter text to speak")
+      return
+    }
+    if ("speechSynthesis" in window) {
+      const utterance = new SpeechSynthesisUtterance(text)
+      window.speechSynthesis.speak(utterance)
+    } else {
+      toast.error("Speech synthesis not supported")
+    }
+  }
+
   const handleSubmit = (e) => {
     e.preventDefault()
     // if (!front.trim() || !back.trim()) return
@@ -23,8 +37,7 @@ export function CardForm({ editingCard, onCancel }) {
       updateCard(editingCard.id, { front: front.trim(), back: back.trim() })
     } else {
       addCard(front?.trim(), back?.trim(), frontImage, backImage)
-
-      
+      speakText(front)
     }
 
     setFront("")
@@ -45,60 +58,70 @@ export function CardForm({ editingCard, onCancel }) {
             <label htmlFor="front" className="block text-sm font-medium mb-2">
               Front (Question)
             </label>
-            <div className="grid grid-cols-4 gap-4">
-            <Textarea
-              id="front"
-              value={front}
-              onChange={(e) => setFront(e.target.value)}
-              placeholder="Enter the question or prompt..."
-              className="min-h-[100px] col-span-3"
-              
-            />
-            {/* <input
-              type="file"
-              accept="image/*"
-              onChange={(e) => setFrontImage(e.target.files[0])}
-              className="bg-blue-500 text-white shadow-[0_0_10px_bg-blue-600] hover:bg-blue-400 hover:text-white hover:shadow-[0_0_10px_bg-blue-600]"
-            /> */}
+              <div className="grid grid-cols-5 gap-4">
+              <Textarea
+                id="front"
+                value={front}
+                onChange={(e) => setFront(e.target.value)}
+                placeholder="Enter the question or prompt..."
+                className="min-h-[100px] col-span-3"
 
-            <label htmlFor="frontImage" className="flex justify-center items-center"> 
-                <img className='w-20 h-20' src={!frontImage ? assets.upload_area : URL.createObjectURL(frontImage)} alt="" />
-                <input 
-                  type="file"
-                  accept="image/*"
-                  id="frontImage"
-                  onChange={(e) => setFrontImage(e.target.files[0])}
-                  hidden
-                />
-            </label>
-            </div>
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => speakText(front)}
+                className="h-10 w-10 col-span-1"
+              >
+                <Volume2 className="h-5 w-5" />
+              </Button>
+              <label htmlFor="frontImage" className="flex justify-center items-center col-span-1">
+                  <img className='w-20 h-20' src={!frontImage ? assets.upload_area : URL.createObjectURL(frontImage)} alt="" />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    id="frontImage"
+                    onChange={(e) => setFrontImage(e.target.files[0])}
+                    hidden
+                  />
+              </label>
+              </div>
           </div>
 
           <div>
             <label htmlFor="back" className="block text-sm font-medium mb-2">
               Back (Answer)
             </label>
-            <div className="grid grid-cols-4 gap-4">
-            <Textarea
-              id="back"
-              value={back}
-              onChange={(e) => setBack(e.target.value)}
-              placeholder="Enter the answer or explanation..."
-              className="min-h-[100px] col-span-3"
-            
-            />
-            
-            <label htmlFor="backImage" className="flex justify-center items-center">
-                <img className='w-20' src={!backImage ? assets.upload_area : URL.createObjectURL(backImage)} alt="" />
-                <input 
-                  type="file"
-                  accept="image/*"
-                  id="backImage"
-                  onChange={(e) => setBackImage(e.target.files[0])}
-                  hidden
-                />
-            </label>
-            </div>
+              <div className="grid grid-cols-5 gap-4">
+              <Textarea
+                id="back"
+                value={back}
+                onChange={(e) => setBack(e.target.value)}
+                placeholder="Enter the answer or explanation..."
+                className="min-h-[100px] col-span-3"
+
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => speakText(back)}
+                className="h-10 w-10 col-span-1"
+              >
+                <Volume2 className="h-5 w-5" />
+              </Button>
+              <label htmlFor="backImage" className="flex justify-center items-center col-span-1">
+                  <img className='w-20' src={!backImage ? assets.upload_area : URL.createObjectURL(backImage)} alt="" />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    id="backImage"
+                    onChange={(e) => setBackImage(e.target.files[0])}
+                    hidden
+                  />
+              </label>
+              </div>
           </div>
 
           <div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary
- add volume buttons to dictate front and back text
- automatically speak card text after adding

## Testing
- `npx eslint src/components/card-form.jsx`
- `npm run lint` *(fails: 'handleEditCard' is assigned a value but never used, Unexpected constant truthiness...)*
- `mvn test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b06d84787c832f81e77980968b4ba2